### PR TITLE
Guest session is enabled by default

### DIFF
--- a/cli/GuestSessionToggle.vala
+++ b/cli/GuestSessionToggle.vala
@@ -100,7 +100,7 @@ namespace GuestSessionToggle {
 	}
 
 	private bool get_allow_guest () {
-		string @value = get_setting ("SeatDefaults", "allow-guest", "false").down ();
+		string @value = get_setting ("SeatDefaults", "allow-guest", "true").down ();
 		return (@value == "true");
 	}
 	


### PR DESCRIPTION
LightDM enables the guest session by default if no configuration option is present. A previous commit changed the default value in the `guest-session-toggle CLI` to false. This PR reverts that change.

Fixes #24.