### PR TITLE
ListFooter.vala: Sort out conditional spaghetti

### DIFF
--- a/src/Widgets/ListFooter.vala
+++ b/src/Widgets/ListFooter.vala
@@ -81,7 +81,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
                 button_remove.set_tooltip_text (_("You cannot remove your own user account"));
             }
 
-            if (get_removal_list () == null || get_removal_list ().last () == null) {
+            if (get_removal_list ().last () == null) {
                 hide_undo_notification ();
             }
         }

--- a/src/Widgets/ListFooter.vala
+++ b/src/Widgets/ListFooter.vala
@@ -43,7 +43,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
             add (button_remove);
 
             button_add.clicked.connect (() => {
-                Widgets.NewUserPopover new_user = new Widgets.NewUserPopover (button_add);
+                var new_user = new Widgets.NewUserPopover (button_add);
                 new_user.show_all ();
                 new_user.request_user_creation.connect (create_new_user);
             });
@@ -62,32 +62,28 @@ namespace SwitchboardPlugUserAccounts.Widgets {
 
         private void update_ui () {
             if (get_permission ().allowed) {
-                button_add.set_sensitive (true);
-                if (selected_user != null && selected_user != get_current_user ()
-                && !is_last_admin (selected_user) && !selected_user.get_automatic_login ()) {
-                    button_remove.set_sensitive (true);
-                    button_remove.set_tooltip_text (_("Remove user account and its data"));
-                } else {
-                    button_remove.set_sensitive (false);
-                    if (selected_user != null) {
-                        button_remove.set_tooltip_text (_("You cannot remove your own user account"));
-                    } else {
-                        button_remove.set_tooltip_text ("");
-                    }
-                }
-
-                if (get_removal_list () == null || get_removal_list ().last () == null) {
-                    hide_undo_notification ();
-                }
-            } else if (selected_user == null) {
-                button_remove.set_sensitive (false);
+                button_add.sensitive = true;
             } else {
-                button_add.set_sensitive (false);
-                button_remove.set_sensitive (false);
+                button_add.sensitive = false;
+                button_remove.sensitive = false;
                 hide_undo_notification ();
+                return;
             }
 
-            show_all ();
+            if (selected_user == null) {
+                button_remove.sensitive = false;
+                button_remove.tooltip_text = "";
+            } else if (selected_user != get_current_user () && !is_last_admin (selected_user) && !selected_user.get_automatic_login ()) {
+                button_remove.sensitive = true;
+                button_remove.tooltip_text = _("Remove user account and its data");
+            } else {
+                button_remove.sensitive = false;
+                button_remove.set_tooltip_text (_("You cannot remove your own user account"));
+            }
+
+            if (get_removal_list () == null || get_removal_list ().last () == null) {
+                hide_undo_notification ();
+            }
         }
 
         public void set_selected_user (Act.User? _user) {


### PR DESCRIPTION
This attempts to sort out some gross spaghetti with deciding the sensitivity state of add and remove buttons.

Firstly, we check if we have permission. If we don't have permission, set insensitive and GTFO. There's no point doing all this other stuff if we can't actually do any stuff.

Then we check if the selected user is `null`. This basically means it's the guest account. We do this first because it's cheap: we're only checking one thing.

If the selected user is not the guest, we check to make sure that it isn't ourselves, the last admin on the system, or... they have an auto login I guess? I'm not really sure why that's there. But hey we'll keep it because whatever. As long as the selected user isn't one of those things, they can be removed.

If the selected user is one of these things, they can't be removed so yeah. For some reason the tooltip text here assumes that this must be ourselves. This is not really accurate though right since some other user could have authed and tried to remove the last admin or something. So yeah. I guess that's a `FIXME`?

Remove this `show_all ()` because we haven't added anything new, we're just setting sensitivity.