### PR TITLE
Move ErrorRevealer to its own class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ vala_precompile (VALA_C ${CMAKE_PROJECT_NAME}
     Views/GuestSettingsView.vala
     Views/MainView.vala
     Views/UserSettingsView.vala
+    Widgets/ErrorRevealer.vala
     Widgets/UserListBox.vala
     Widgets/ListFooter.vala
     Widgets/UserItem.vala

--- a/src/Dialogs/NewUserDialog.vala
+++ b/src/Dialogs/NewUserDialog.vala
@@ -257,27 +257,4 @@ public class SwitchboardPlugUserAccounts.NewUserDialog : Gtk.Dialog {
     private class ValidatedEntry : Gtk.Entry {
         public bool is_valid { get; set; default = false; }
     }
-
-    private class ErrorRevealer : Gtk.Revealer {
-        public Gtk.Label label_widget;
-
-        public string label {
-            set {
-                label_widget.label = "<span font_size=\"small\">%s</span>".printf (value);
-            }
-        }
-
-        public ErrorRevealer (string label) {
-            label_widget = new Gtk.Label ("<span font_size=\"small\">%s</span>".printf (label));
-            label_widget.halign = Gtk.Align.END;
-            label_widget.justify = Gtk.Justification.RIGHT;
-            label_widget.max_width_chars = 55;
-            label_widget.use_markup = true;
-            label_widget.wrap = true;
-            label_widget.xalign = 1;
-
-            transition_type = Gtk.RevealerTransitionType.CROSSFADE;
-            add (label_widget);
-        }
-    }
 }

--- a/src/Widgets/ErrorRevealer.vala
+++ b/src/Widgets/ErrorRevealer.vala
@@ -20,14 +20,26 @@
 private class SwitchboardPlugUserAccounts.ErrorRevealer : Gtk.Revealer {
     public Gtk.Label label_widget;
 
+    private string _label;
     public string label {
-        set {
-            label_widget.label = "<span font_size=\"small\">%s</span>".printf (value);
+        get {
+            return _label;
+        }
+        construct set {
+            _label = value;
+
+            if (label_widget != null) {
+                label_widget.label = "<span font_size=\"small\">%s</span>".printf (value);
+            }
         }
     }
 
     public ErrorRevealer (string label) {
-        label_widget = new Gtk.Label ("<span font_size=\"small\">%s</span>".printf (label));
+        Object (label: label);
+    }
+
+    construct {
+        label_widget = new Gtk.Label ("<span font_size=\"small\">%s</span>".printf (_label));
         label_widget.halign = Gtk.Align.END;
         label_widget.justify = Gtk.Justification.RIGHT;
         label_widget.max_width_chars = 55;

--- a/src/Widgets/ErrorRevealer.vala
+++ b/src/Widgets/ErrorRevealer.vala
@@ -1,0 +1,41 @@
+/*
+* Copyright (c) 2018 elementary LLC. (https://elementary.io)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*/
+
+private class SwitchboardPlugUserAccounts.ErrorRevealer : Gtk.Revealer {
+    public Gtk.Label label_widget;
+
+    public string label {
+        set {
+            label_widget.label = "<span font_size=\"small\">%s</span>".printf (value);
+        }
+    }
+
+    public ErrorRevealer (string label) {
+        label_widget = new Gtk.Label ("<span font_size=\"small\">%s</span>".printf (label));
+        label_widget.halign = Gtk.Align.END;
+        label_widget.justify = Gtk.Justification.RIGHT;
+        label_widget.max_width_chars = 55;
+        label_widget.use_markup = true;
+        label_widget.wrap = true;
+        label_widget.xalign = 1;
+
+        transition_type = Gtk.RevealerTransitionType.CROSSFADE;
+        add (label_widget);
+    }
+}

--- a/src/Widgets/PasswordEditor.vala
+++ b/src/Widgets/PasswordEditor.vala
@@ -19,14 +19,13 @@
 
 namespace SwitchboardPlugUserAccounts.Widgets {
     public class PasswordEditor : Gtk.Grid {
+        private ErrorRevealer error_revealer;
+        private ErrorRevealer error_new_revealer;
         private Gtk.Entry current_pw_entry;
         private Gtk.Entry new_pw_entry;
         private Gtk.Entry confirm_pw_entry;
         private Gtk.CheckButton show_pw_check;
         private Gtk.LevelBar pw_level;
-        private Gtk.Revealer error_revealer;
-        private Gtk.Revealer error_new_revealer;
-        private Gtk.Label error_new_label;
 
         private PasswordQuality.Settings pwquality;
 
@@ -55,15 +54,9 @@ namespace SwitchboardPlugUserAccounts.Widgets {
                 current_pw_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, null);
                 current_pw_entry.set_icon_tooltip_text (Gtk.EntryIconPosition.SECONDARY, _("Press to authenticate"));
 
-                var error_pw_label = new Gtk.Label ("<span font_size=\"small\">%s</span>".printf (_("Authentication failed")));
-                error_pw_label.halign = Gtk.Align.END;
-                error_pw_label.margin_top = 10;
-                error_pw_label.use_markup = true;
-                error_pw_label.get_style_context ().add_class ("error");
-
-                error_revealer = new Gtk.Revealer ();
-                error_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN;
-                error_revealer.add (error_pw_label);
+                error_revealer = new ErrorRevealer (_("Authentication failed"));
+                error_revealer.label_widget.get_style_context ().add_class (Gtk.STYLE_CLASS_ERROR);
+                error_revealer.margin_top = 3;
 
                 current_pw_entry.changed.connect (() => {
                     if (current_pw_entry.text.length > 0) {
@@ -88,18 +81,9 @@ namespace SwitchboardPlugUserAccounts.Widgets {
                 attach (error_revealer, 0, 1, 1, 1);
             }
 
-            error_new_label = new Gtk.Label ("");
-            error_new_label.halign = Gtk.Align.END;
-            error_new_label.justify = Gtk.Justification.RIGHT;
-            error_new_label.margin_top = 10;
-            error_new_label.max_width_chars = 30;
-            error_new_label.use_markup = true;
-            error_new_label.wrap = true;
-            error_new_label.get_style_context ().add_class ("error");
-
-            error_new_revealer = new Gtk.Revealer ();
-            error_new_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN;
-            error_new_revealer.add (error_new_label);
+            error_new_revealer = new ErrorRevealer (".");
+            error_new_revealer.label_widget.get_style_context ().add_class (Gtk.STYLE_CLASS_WARNING);
+            error_new_revealer.margin_top = 3;
 
             new_pw_entry = new Gtk.Entry ();
             new_pw_entry.placeholder_text = _("New Password");
@@ -114,7 +98,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
             new_pw_entry.changed.connect (compare_passwords);
 
             pw_level = new Gtk.LevelBar.for_interval (0.0, 100.0);
-            pw_level.margin_top = 10;
+            pw_level.margin_top = 3;
             pw_level.mode = Gtk.LevelBarMode.CONTINUOUS;
             pw_level.add_offset_value ("low", 50.0);
             pw_level.add_offset_value ("high", 75.0);
@@ -140,8 +124,8 @@ namespace SwitchboardPlugUserAccounts.Widgets {
             });
 
             attach (new_pw_entry, 0, 2, 1, 1);
-            attach (error_new_revealer, 0, 3, 1, 1);
-            attach (pw_level, 0, 4, 1, 1);
+            attach (pw_level, 0, 3, 1, 1);
+            attach (error_new_revealer, 0, 4, 1, 1);
             attach (confirm_pw_entry, 0, 5, 1, 1);
             attach (show_pw_check, 0, 6, 1, 1);
 
@@ -188,7 +172,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
                     var pw_error = (PasswordQuality.Error) quality;
                     var error_string = pw_error.to_string (error);
 
-                    error_new_label.label = "<span font_size=\"small\">%s</span>".printf (error_string);
+                    error_new_revealer.label_widget.label = "<span font_size=\"small\">%s</span>".printf (error_string);
                     error_new_revealer.reveal_child = true;
 
                     /* With admin privileges the new password doesn't need to pass the obscurity test */

--- a/src/Widgets/PasswordEditor.vala
+++ b/src/Widgets/PasswordEditor.vala
@@ -81,7 +81,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
                 attach (error_revealer, 0, 1, 1, 1);
             }
 
-            error_new_revealer = new ErrorRevealer (".");
+            error_new_revealer = new ErrorRevealer ("."); // Pango needs a non-null string to set markup
             error_new_revealer.label_widget.get_style_context ().add_class (Gtk.STYLE_CLASS_WARNING);
             error_new_revealer.margin_top = 3;
 


### PR DESCRIPTION
There's definitely a lot more work here to be done as far as de-duplicating things between the new user dialog and change password popover, but here is one step