### PR TITLE
ChangePasswordDialog: remove redundant check

### DIFF
--- a/src/Dialogs/ChangePasswordDialog.vala
+++ b/src/Dialogs/ChangePasswordDialog.vala
@@ -61,11 +61,7 @@ public class SwitchboardPlugUserAccounts.ChangePasswordDialog : Gtk.Dialog {
         });
 
         button_change.clicked.connect (() => {
-            if (pw_editor.is_valid) {
-                request_password_change (Act.UserPasswordMode.REGULAR, pw_editor.get_password ());
-            }
-
-            hide ();
+            request_password_change (Act.UserPasswordMode.REGULAR, pw_editor.get_password ());
             destroy ();
         });
 


### PR DESCRIPTION
If this button is sensitive (aka clickable) then `pw_editor.is_valid`. So it doesn't make sense to check this when it must be true