### PR TITLE
PasswordEditor: copy layout from NewUserDialog

### DIFF
--- a/src/Dialogs/NewUserDialog.vala
+++ b/src/Dialogs/NewUserDialog.vala
@@ -53,18 +53,18 @@ public class SwitchboardPlugUserAccounts.NewUserDialog : Gtk.Dialog {
 
         var pw_label = new Granite.HeaderLabel (_("Choose a Password"));
 
-        pw_error_revealer = new ErrorRevealer (".");
-        pw_error_revealer.label_widget.get_style_context ().add_class (Gtk.STYLE_CLASS_WARNING);
-
         pw_entry = new ValidatedEntry ();
         pw_entry.visibility = false;
 
-        pw_levelbar = new Gtk.LevelBar ();
         pw_levelbar = new Gtk.LevelBar.for_interval (0.0, 100.0);
         pw_levelbar.set_mode (Gtk.LevelBarMode.CONTINUOUS);
         pw_levelbar.add_offset_value ("low", 50.0);
         pw_levelbar.add_offset_value ("high", 75.0);
         pw_levelbar.add_offset_value ("middle", 75.0);
+
+        pw_error_revealer = new ErrorRevealer (".");
+        pw_error_revealer.label_widget.get_style_context ().add_class (Gtk.STYLE_CLASS_WARNING);
+
 
         var confirm_label = new Granite.HeaderLabel (_("Confirm Password"));
 

--- a/src/Dialogs/NewUserDialog.vala
+++ b/src/Dialogs/NewUserDialog.vala
@@ -65,7 +65,6 @@ public class SwitchboardPlugUserAccounts.NewUserDialog : Gtk.Dialog {
         pw_error_revealer = new ErrorRevealer (".");
         pw_error_revealer.label_widget.get_style_context ().add_class (Gtk.STYLE_CLASS_WARNING);
 
-
         var confirm_label = new Granite.HeaderLabel (_("Confirm Password"));
 
         confirm_entry = new ValidatedEntry ();


### PR DESCRIPTION
This changes PasswordEditor to be a little bit more like the password validation from NewUserDialog. It isn't meant to be a complete port, just one step closer in a series of small PRs

* Fixes out of order widget and extra widget in NewUserDialog
* Uses a revealer for confirm entry error messages
* Add header labels for entries instead of placeholder text
* Renames lots of variable names to be the same
* Set the grid orientation to vertical and use `add`
* Use settings bindings for show password check
* Don't use tooltips to communicate errors or warnings