### PR TITLE
Use process-error-symbolic

### DIFF
--- a/src/Dialogs/NewUserDialog.vala
+++ b/src/Dialogs/NewUserDialog.vala
@@ -141,7 +141,7 @@ public class SwitchboardPlugUserAccounts.NewUserDialog : Gtk.Dialog {
             }
 
             username_error_revealer.reveal_child = true;
-            username_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "dialog-error-symbolic");
+            username_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "process-error-symbolic");
         }
 
         return false;

--- a/src/Widgets/PasswordEditor.vala
+++ b/src/Widgets/PasswordEditor.vala
@@ -139,7 +139,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
         private bool confirm_password () {
             if (confirm_entry.text != "") {
                 if (pw_entry.text != confirm_entry.text) {
-                    confirm_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "dialog-error-symbolic");
+                    confirm_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "process-error-symbolic");
                     confirm_entry_revealer.label = _("Passwords do not match");
                     confirm_entry_revealer.reveal_child = true;
                 } else {


### PR DESCRIPTION
Uses `process-error-symbolic` instead of `dialog-error-symbolic` which matches better with `process-completed-symbolic`