### PR TITLE
Always update current user's keyring

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -107,9 +107,7 @@ namespace SwitchboardPlugUserAccounts {
             main_grid.show_all ();
 
             get_permission ().notify["allowed"].connect (() => {
-                if (get_permission ().allowed) {
-                    infobar.visible = false;
-                }
+                infobar.visible = !get_permission ().allowed;
             });
 
             return main_grid;

--- a/src/Views/UserSettingsView.vala
+++ b/src/Views/UserSettingsView.vala
@@ -182,7 +182,9 @@ namespace SwitchboardPlugUserAccounts.Widgets {
             password_button = new Gtk.Button.with_label (_("Change Password…"));
             password_button.clicked.connect (() => {
                 InfobarNotifier.get_default ().unset_error ();
-
+                if (user == get_current_user ()) {
+                    get_permission ().release ();
+                }
                 var change_password_dialog = new ChangePasswordDialog ((Gtk.Window) this.get_toplevel (), user);
                 change_password_dialog.present ();
                 change_password_dialog.request_password_change.connect (utils.change_password);

--- a/src/Views/UserSettingsView.vala
+++ b/src/Views/UserSettingsView.vala
@@ -182,9 +182,15 @@ namespace SwitchboardPlugUserAccounts.Widgets {
             password_button = new Gtk.Button.with_label (_("Change Password…"));
             password_button.clicked.connect (() => {
                 InfobarNotifier.get_default ().unset_error ();
-                if (user == get_current_user ()) {
-                    get_permission ().release ();
+                if (user == get_current_user () && get_permission ().allowed) {
+                    try {
+                        get_permission ().release ();
+                    } catch (Error e){
+                        warning ("Error releasing privileges:");
+                        warning (e.message);
+                    }
                 }
+
                 var change_password_dialog = new ChangePasswordDialog ((Gtk.Window) this.get_toplevel (), user);
                 change_password_dialog.present ();
                 change_password_dialog.request_password_change.connect (utils.change_password);

--- a/src/Views/UserSettingsView.vala
+++ b/src/Views/UserSettingsView.vala
@@ -182,12 +182,12 @@ namespace SwitchboardPlugUserAccounts.Widgets {
             password_button = new Gtk.Button.with_label (_("Change Password…"));
             password_button.clicked.connect (() => {
                 InfobarNotifier.get_default ().unset_error ();
-                if (user == get_current_user () && get_permission ().allowed) {
+                var permission = get_permission ();
+                if (user == get_current_user () && permission.allowed) {
                     try {
-                        get_permission ().release ();
+                        permission.release ();
                     } catch (Error e){
-                        warning ("Error releasing privileges:");
-                        warning (e.message);
+                        critical ("Error releasing privileges: %s", e.message);
                     }
                 }
 


### PR DESCRIPTION
Releases privileges if updating current user's password and updates infobar visibility logic
Fixes #15 