### PR TITLE
UserItem: bind username change to its own property

### DIFF
--- a/src/Widgets/UserItem.vala
+++ b/src/Widgets/UserItem.vala
@@ -26,6 +26,12 @@ namespace SwitchboardPlugUserAccounts.Widgets {
 
         public weak Act.User user { get; construct; }
 
+        public string user_name {
+            set {
+                username_label.label = "<small>%s</small>".printf (GLib.Markup.escape_text (value));
+            }
+        }
+
         public UserItem (Act.User user) {
             Object (user: user);
         }
@@ -74,6 +80,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
 
             user.bind_property ("real-name", full_name_label, "label", GLib.BindingFlags.SYNC_CREATE);
             user.bind_property ("locked", lock_revealer, "reveal-child", GLib.BindingFlags.SYNC_CREATE);
+            user.bind_property ("user-name", this, "user-name", GLib.BindingFlags.SYNC_CREATE);
         }
 
         public void update_ui () {
@@ -84,8 +91,6 @@ namespace SwitchboardPlugUserAccounts.Widgets {
             } catch (Error e) {
                 avatar.show_default (32);
             }
-
-            username_label.label = "<span font_size=\"small\">%s</span>".printf (GLib.Markup.escape_text (user.get_user_name ()));
 
             if (user.get_account_type () == Act.UserAccountType.ADMINISTRATOR) {
                 description_label.no_show_all = false;


### PR DESCRIPTION
In the vein of #110, only setting things which have actually changed