### PR TITLE
build: fix install path for switchboard plug

### DIFF
--- a/cli/meson.build
+++ b/cli/meson.build
@@ -7,5 +7,5 @@ executable(
         posix_dep
     ],
     install : true,
-    install_dir : join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir'), 'system', 'pantheon-useraccounts')
+    install_dir : join_paths(switchboard_plugsdir, 'system', 'pantheon-useraccounts')
 )

--- a/data/meson.build
+++ b/data/meson.build
@@ -9,7 +9,7 @@ i18n.merge_file(
     output: 'org.pantheon.switchboard.user-accounts.policy',
     po_dir: join_paths(meson.source_root(), 'po', 'extra'),
     install: true,
-    install_dir: act_dir
+    install_dir: polkit_actiondir
 )
 
 i18n.merge_file(
@@ -18,5 +18,5 @@ i18n.merge_file(
     po_dir: join_paths(meson.source_root(), 'po', 'extra'),
     type: 'xml',
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'metainfo'),
+    install_dir: join_paths(datadir, 'metainfo'),
 )

--- a/meson.build
+++ b/meson.build
@@ -5,14 +5,22 @@ project(
     version: '2.2.1'
 )
 
-switchboard_dep = dependency('switchboard-2.0')
-gettext_name = meson.project_name() + '-plug'
 gnome = import('gnome')
 i18n = import('i18n')
-pkg_data_dir =  join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir'), 'system', 'pantheon-useraccounts')
-act_dir =  join_paths(get_option('datadir'), 'polkit-1', 'actions')
-posix_dep = meson.get_compiler('vala').find_library('posix')
 
+gettext_name = meson.project_name() + '-plug'
+
+prefix = get_option('prefix')
+datadir = join_paths(prefix, get_option('datadir'))
+libdir = join_paths(prefix, get_option('libdir'))
+
+switchboard_dep = dependency('switchboard-2.0')
+switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir')
+pkgdatadir = join_paths(switchboard_plugsdir, 'system', 'pantheon-useraccounts')
+
+polkit_actiondir = join_paths(get_option('datadir'), 'polkit-1', 'actions')
+
+posix_dep = meson.get_compiler('vala').find_library('posix')
 
 add_project_arguments('-DGETTEXT_PACKAGE="@0@"'.format(gettext_name), language:'c')
 add_project_arguments('-DGNOME_DESKTOP_USE_UNSTABLE_API', language: 'c')
@@ -20,7 +28,7 @@ add_project_arguments(['--vapidir', join_paths(meson.current_source_dir(), 'vapi
 
 configuration_data = configuration_data()
 configuration_data.set('GETTEXT_PACKAGE', gettext_name)
-configuration_data.set('PKGDATADIR', pkg_data_dir)
+configuration_data.set('PKGDATADIR', pkgdatadir)
 
 subdir('cli')
 subdir('data')

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ datadir = join_paths(prefix, get_option('datadir'))
 libdir = join_paths(prefix, get_option('libdir'))
 
 switchboard_dep = dependency('switchboard-2.0')
-switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir')
+switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir])
 pkgdatadir = join_paths(switchboard_plugsdir, 'system', 'pantheon-useraccounts')
 
 polkit_actiondir = join_paths(get_option('datadir'), 'polkit-1', 'actions')

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,8 @@ switchboard_dep = dependency('switchboard-2.0')
 switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir])
 pkgdatadir = join_paths(switchboard_plugsdir, 'system', 'pantheon-useraccounts')
 
-polkit_actiondir = join_paths(get_option('datadir'), 'polkit-1', 'actions')
+polkit_dep = dependency('polkit-gobject-1')
+polkit_actiondir = polkit_dep.get_pkgconfig_variable('actiondir', define_variable: ['prefix', prefix])
 
 posix_dep = meson.get_compiler('vala').find_library('posix')
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -51,5 +51,5 @@ shared_module(
         switchboard_dep
     ],
     install: true,
-    install_dir : join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir'), 'system')
+    install_dir : join_paths(switchboard_plugsdir, 'system')
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -38,17 +38,17 @@ shared_module(
     dependencies: [
         dependency('accountsservice'),
         dependency('gee-0.8'),
+        dependency('gio-2.0'),
         dependency('glib-2.0'),
         dependency('gnome-desktop-3.0'),
-        dependency('gio-2.0'),
         dependency('gobject-2.0'),
         dependency('granite', version: '>=5.2.0'),
         dependency('gtk+-3.0'),
-        dependency('polkit-gobject-1'),
         dependency('pwquality'),
         meson.get_compiler('vala').find_library('run-passwd', dirs: join_paths(meson.current_source_dir())),
+        polkit_dep,
         posix_dep,
-        switchboard_dep
+        switchboard_dep,
     ],
     install: true,
     install_dir : join_paths(switchboard_plugsdir, 'system')


### PR DESCRIPTION
On NixOS all packages are installed into their own immutable prefix.
Because of this switchboard_dep.get_pkgconfig_variable will return a
path from within switchboard's prefix and we cannot write to it.
By using define_variable we can replace the libdir to be from the
paths from meson. This should have no affect on elementaryOS.

---

Also includes https://github.com/elementary/switchboard-plug-useraccounts/commit/eec88f92735c952558b0e3a7a5335d281d132420 for completion.