### PR TITLE
Fix deprecations

### DIFF
--- a/src/Dialogs/ChangePasswordDialog.vala
+++ b/src/Dialogs/ChangePasswordDialog.vala
@@ -87,18 +87,15 @@ public class SwitchboardPlugUserAccounts.ChangePasswordDialog : Gtk.Dialog {
         window_position = Gtk.WindowPosition.CENTER_ON_PARENT;
         get_content_area ().add (form_grid);
 
-        var cancel_button = new Gtk.Button.with_label (_("Cancel"));
+        var cancel_button = add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
+        cancel_button.margin_bottom = 6;
+        cancel_button.margin_top = 14;
 
-        var button_change = new Gtk.Button.with_label (_("Change Password"));
+        var button_change = add_button (_("Change Password"), Gtk.ResponseType.OK);
+        button_change.margin = 6;
+        button_change.margin_top = 14;
         button_change.sensitive = false;
         button_change.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
-
-        var action_area = (Gtk.Container) get_action_area ();
-        action_area.margin = 6;
-        action_area.margin_top = 14;
-        action_area.add (cancel_button);
-        action_area.add (button_change);
-        action_area.show_all ();
 
         pw_editor.validation_changed.connect (() => {
             var permission = get_permission ();
@@ -114,12 +111,11 @@ public class SwitchboardPlugUserAccounts.ChangePasswordDialog : Gtk.Dialog {
             }
         });
 
-        button_change.clicked.connect (() => {
-            request_password_change (Act.UserPasswordMode.REGULAR, pw_editor.get_password ());
-            destroy ();
-        });
+        response.connect ((response_id) => {
+            if (response_id == Gtk.ResponseType.OK) {
+                request_password_change (Act.UserPasswordMode.REGULAR, pw_editor.get_password ());
+            }
 
-        cancel_button.clicked.connect (() => {
             destroy ();
         });
     }

--- a/src/Dialogs/NewUserDialog.vala
+++ b/src/Dialogs/NewUserDialog.vala
@@ -74,19 +74,16 @@ public class SwitchboardPlugUserAccounts.NewUserDialog : Gtk.Dialog {
         window_position = Gtk.WindowPosition.CENTER_ON_PARENT;
         get_content_area ().add (form_grid);
 
-        var cancel_button = new Gtk.Button.with_label (_("Cancel"));
+        var cancel_button = add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
+        cancel_button.margin_bottom = 6;
+        cancel_button.margin_top = 14;
 
-        create_button = new Gtk.Button.with_label (_("Create User"));
+        create_button = (Gtk.Button) add_button (_("Create User"), Gtk.ResponseType.OK);
+        create_button.margin = 6;
+        create_button.margin_top = 14;
         create_button.can_default = true;
         create_button.sensitive = false;
         create_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
-
-        var action_area = (Gtk.Container) get_action_area ();
-        action_area.margin = 6;
-        action_area.margin_top = 14;
-        action_area.add (cancel_button);
-        action_area.add (create_button);
-        action_area.show_all ();
 
         realname_entry.changed.connect (() => {
             var username = gen_username (realname_entry.text);
@@ -102,35 +99,33 @@ public class SwitchboardPlugUserAccounts.NewUserDialog : Gtk.Dialog {
             update_create_button ();
         });
 
-        ((Gtk.Button) cancel_button).clicked.connect (() => {
-            destroy ();
-        });
+        response.connect ((response_id) => {
+            if (response_id == Gtk.ResponseType.OK) {
+                string fullname = realname_entry.text;
+                string username = username_entry.text;
+                string password = pw_editor.get_password ();
+                Act.UserAccountType accounttype = Act.UserAccountType.STANDARD;
 
-        create_button.clicked.connect (() => {
-            string fullname = realname_entry.text;
-            string username = username_entry.text;
-            string password = pw_editor.get_password ();
-            Act.UserAccountType accounttype = Act.UserAccountType.STANDARD;
+                if (accounttype_combobox.get_active () == 1) {
+                    accounttype = Act.UserAccountType.ADMINISTRATOR;
+                }
 
-            if (accounttype_combobox.get_active () == 1) {
-                accounttype = Act.UserAccountType.ADMINISTRATOR;
-            }
+                if (get_permission ().allowed) {
+                    try {
+                        var created_user = get_usermanager ().create_user (username, fullname, accounttype);
 
-            if (get_permission ().allowed) {
-                try {
-                    var created_user = get_usermanager ().create_user (username, fullname, accounttype);
+                        get_usermanager ().user_added.connect ((user) => {
+                            if (user == created_user) {
+                                created_user.set_locked (false);
 
-                    get_usermanager ().user_added.connect ((user) => {
-                        if (user == created_user) {
-                            created_user.set_locked (false);
-
-                            if (password != null) {
-                                created_user.set_password (password, "");
+                                if (password != null) {
+                                    created_user.set_password (password, "");
+                                }
                             }
-                        }
-                    });
-                } catch (Error e) {
-                    critical ("Creation of user '%s' failed".printf (username));
+                        });
+                    } catch (Error e) {
+                        critical ("Creation of user '%s' failed".printf (username));
+                    }
                 }
             }
 


### PR DESCRIPTION
## Changes Summary
- Ditch deprecated `Gtk.Dialog.get_action_area ()`
- Use the `response` signal instead of `clicked` one

## BEFORE
![Screenshot from 2019-10-30 20-36-42](https://user-images.githubusercontent.com/26003928/67857194-7bd92400-fb59-11e9-89d8-5ab4d3378f62.png)

![Screenshot from 2019-10-30 21-08-35](https://user-images.githubusercontent.com/26003928/67857197-7c71ba80-fb59-11e9-9256-4a32a1ec8555.png)

## AFTER
![Screenshot from 2019-10-30 21-00-35](https://user-images.githubusercontent.com/26003928/67857195-7bd92400-fb59-11e9-8b6f-a34c7c383634.png)

![Screenshot from 2019-10-30 21-07-20](https://user-images.githubusercontent.com/26003928/67857196-7bd92400-fb59-11e9-8c63-9f2b51b5707f.png)
