### PR TITLE
Create user without user_added signal

### DIFF
--- a/src/Dialogs/NewUserDialog.vala
+++ b/src/Dialogs/NewUserDialog.vala
@@ -114,16 +114,11 @@ public class SwitchboardPlugUserAccounts.NewUserDialog : Gtk.Dialog {
                 if (get_permission ().allowed) {
                     try {
                         var created_user = get_usermanager ().create_user (username, fullname, accounttype);
+                        if (password != null) {
+                            created_user.set_password (password, "");
+                        }
 
-                        get_usermanager ().user_added.connect ((user) => {
-                            if (user == created_user) {
-                                created_user.set_locked (false);
-
-                                if (password != null) {
-                                    created_user.set_password (password, "");
-                                }
-                            }
-                        });
+                        created_user.set_locked (false);
                     } catch (Error e) {
                         critical ("Creation of user '%s' failed", username);
                     }


### PR DESCRIPTION
This is the same as https://github.com/elementary/initial-setup/pull/81

Prevents us getting users that are locked after creation on `focal`.~~I've tested that this also works properly on `bionic` too and all good.~~

Edit: wait, I haven't tested this on bionic, I'm an idiot.