### PR TITLE
PasswordEditor: Adjust password levelbar values

### DIFF
--- a/src/Widgets/PasswordEditor.vala
+++ b/src/Widgets/PasswordEditor.vala
@@ -44,9 +44,10 @@ namespace SwitchboardPlugUserAccounts.Widgets {
 
             pw_levelbar = new Gtk.LevelBar.for_interval (0.0, 100.0);
             pw_levelbar.mode = Gtk.LevelBarMode.CONTINUOUS;
-            pw_levelbar.add_offset_value ("low", 50.0);
-            pw_levelbar.add_offset_value ("high", 75.0);
-            pw_levelbar.add_offset_value ("middle", 75.0);
+            pw_levelbar.add_offset_value ("low", 30.0);
+            pw_levelbar.add_offset_value ("middle", 50.0);
+            pw_levelbar.add_offset_value ("high", 80.0);
+            pw_levelbar.add_offset_value ("full", 100.0);
 
             pw_error_revealer = new ErrorRevealer ("."); // Pango needs a non-null string to set markup
             pw_error_revealer.label_widget.get_style_context ().add_class (Gtk.STYLE_CLASS_WARNING);


### PR DESCRIPTION
Gives us a nice scale from red to green:
![Screenshot from 2020-05-11 16 55 37@2x](https://user-images.githubusercontent.com/7277719/81623414-52bb0b00-93a8-11ea-83d4-a5638c6abcda.png)
![Screenshot from 2020-05-11 16 55 46@2x](https://user-images.githubusercontent.com/7277719/81623422-56e72880-93a8-11ea-8cdc-e7011e21cfb0.png)
![Screenshot from 2020-05-11 16 55 54@2x](https://user-images.githubusercontent.com/7277719/81623425-59498280-93a8-11ea-8408-b683459c782d.png)
![Screenshot from 2020-05-11 16 56 03@2x](https://user-images.githubusercontent.com/7277719/81623428-5babdc80-93a8-11ea-8dc1-40846226ab88.png)
