### PR TITLE
UserSettingsView: skip checking delta user when updating avatar

### DIFF
--- a/src/Misc/DeltaUser.vala
+++ b/src/Misc/DeltaUser.vala
@@ -27,7 +27,6 @@ public class SwitchboardPlugUserAccounts.DeltaUser : Object {
     public bool automatic_login { public get; private set; }
     public bool locked { public get; private set; }
     public Act.UserPasswordMode? password_mode { public get; private set; }
-    public string? icon_file { public get; private set; }
     public string? language { public get; private set; }
 
     public DeltaUser (Act.User user) {
@@ -41,7 +40,6 @@ public class SwitchboardPlugUserAccounts.DeltaUser : Object {
         automatic_login = false;
         locked = false;
         password_mode = null;
-        icon_file = null;
         language = null;
     }
 
@@ -51,7 +49,6 @@ public class SwitchboardPlugUserAccounts.DeltaUser : Object {
         automatic_login = user.get_automatic_login ();
         locked = user.get_locked ();
         password_mode = user.get_password_mode ();
-        icon_file = user.get_icon_file ();
         language = user.get_language ();
     }
 }

--- a/src/Views/UserSettingsView.vala
+++ b/src/Views/UserSettingsView.vala
@@ -322,9 +322,8 @@ namespace SwitchboardPlugUserAccounts.Widgets {
                 update_real_name ();
             }
 
-            if (delta_user.icon_file != user.get_icon_file ()) {
-                avatar.set_image_load_func (avatar_image_load_func);
-            }
+            // Checking delt_user icon file doesn't seem to always update correctly
+            avatar.set_image_load_func (avatar_image_load_func);
 
             if (delta_user.account_type != user.get_account_type ()) {
                 update_account_type ();

--- a/src/Views/UserSettingsView.vala
+++ b/src/Views/UserSettingsView.vala
@@ -322,7 +322,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
                 update_real_name ();
             }
 
-            // Checking delt_user icon file doesn't seem to always update correctly
+            // Checking delta_user icon file doesn't seem to always update correctly
             avatar.set_image_load_func (avatar_image_load_func);
 
             if (delta_user.account_type != user.get_account_type ()) {


### PR DESCRIPTION
Fixes #150 

It seems like maybe delta user isn't updated correctly or something. I also tried listening to `user.notify["icon-file"]` and that wasn't working so I dunno