### PR TITLE
UserSettingsView: split update_ui and update_permission

### DIFF
--- a/src/Views/UserSettingsView.vala
+++ b/src/Views/UserSettingsView.vala
@@ -245,16 +245,18 @@ namespace SwitchboardPlugUserAccounts.Widgets {
             attach (enable_lock, 2, 6, 1, 1);
 
             update_ui ();
-            get_permission ().notify["allowed"].connect (update_ui);
+            update_sensitivity ();
+
+            get_permission ().notify["allowed"].connect (update_sensitivity);
 
             user.changed.connect (update_ui);
         }
 
-        private void update_ui () {
+        private void update_sensitivity () {
             var allowed = get_permission ().allowed;
             var current_user = get_current_user () == user;
-            var last_admin = is_last_admin (user);
             var user_locked = user.get_locked ();
+            var last_admin = is_last_admin (user);
 
             if (!allowed) {
                 user_type_box.set_sensitive (false);
@@ -301,6 +303,11 @@ namespace SwitchboardPlugUserAccounts.Widgets {
                     region_box.set_sensitive (false);
                 }
             }
+        }
+
+        private void update_ui () {
+            var current_user = get_current_user () == user;
+            var last_admin = is_last_admin (user);
 
             if (current_user) {
                 enable_lock.tooltip_text = CURRENT_USER_STRING;
@@ -339,6 +346,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
                 }
             }
 
+            var user_locked = user.get_locked ();
             if (user_locked) {
                 enable_user_button.label = _("Enable User Account");
                 enable_user_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);

--- a/src/Views/UserSettingsView.vala
+++ b/src/Views/UserSettingsView.vala
@@ -245,14 +245,14 @@ namespace SwitchboardPlugUserAccounts.Widgets {
             attach (enable_lock, 2, 6, 1, 1);
 
             update_ui ();
-            update_sensitivity ();
+            update_permission ();
 
-            get_permission ().notify["allowed"].connect (update_sensitivity);
+            get_permission ().notify["allowed"].connect (update_permission);
 
             user.changed.connect (update_ui);
         }
 
-        private void update_sensitivity () {
+        private void update_permission () {
             var allowed = get_permission ().allowed;
             var current_user = get_current_user () == user;
             var user_locked = user.get_locked ();


### PR DESCRIPTION
We don't need to check for updates to name labels etc when permission changes and we don't need to set certain widget sensitivities when names change, so these are split into two separate functions so that we only do the work we need to do when we need to do it