### PR TITLE
Use Granite.ValidatedEntry

### DIFF
--- a/src/Dialogs/NewUserDialog.vala
+++ b/src/Dialogs/NewUserDialog.vala
@@ -21,7 +21,7 @@ public class SwitchboardPlugUserAccounts.NewUserDialog : Granite.Dialog {
     private ErrorRevealer username_error_revealer;
     private Gtk.Button create_button;
     private Widgets.PasswordEditor pw_editor;
-    private ValidatedEntry username_entry;
+    private Granite.ValidatedEntry username_entry;
 
     public NewUserDialog (Gtk.Window parent) {
         Object (transient_for: parent);
@@ -42,7 +42,7 @@ public class SwitchboardPlugUserAccounts.NewUserDialog : Granite.Dialog {
 
         var username_label = new Granite.HeaderLabel (_("Username"));
 
-        username_entry = new ValidatedEntry ();
+        username_entry = new Granite.ValidatedEntry ();
 
         username_error_revealer = new ErrorRevealer (".");
         username_error_revealer.label_widget.get_style_context ().add_class (Gtk.STYLE_CLASS_ERROR);
@@ -136,10 +136,8 @@ public class SwitchboardPlugUserAccounts.NewUserDialog : Granite.Dialog {
 
         if (username_entry_text == "") {
             username_error_revealer.reveal_child = false;
-            username_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, null);
         } else if (username_is_valid && !username_is_taken) {
             username_error_revealer.reveal_child = false;
-            username_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "process-completed-symbolic");
             return true;
         } else {
             if (username_is_taken) {
@@ -149,7 +147,6 @@ public class SwitchboardPlugUserAccounts.NewUserDialog : Granite.Dialog {
             }
 
             username_error_revealer.reveal_child = true;
-            username_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "process-error-symbolic");
         }
 
         return false;
@@ -162,9 +159,5 @@ public class SwitchboardPlugUserAccounts.NewUserDialog : Granite.Dialog {
         } else {
             create_button.sensitive = false;
         }
-    }
-
-    private class ValidatedEntry : Gtk.Entry {
-        public bool is_valid { get; set; default = false; }
     }
 }

--- a/src/Widgets/PasswordEditor.vala
+++ b/src/Widgets/PasswordEditor.vala
@@ -23,7 +23,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
         private ErrorRevealer pw_error_revealer;
         private Gtk.LevelBar pw_levelbar;
         private ValidatedEntry pw_entry;
-        private ValidatedEntry confirm_entry;
+        private Granite.ValidatedEntry confirm_entry;
 
         public Gtk.Entry current_pw_entry { get; construct; }
         public bool is_obscure { get; private set; default = false; }
@@ -54,7 +54,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
 
             var confirm_label = new Granite.HeaderLabel (_("Confirm Password"));
 
-            confirm_entry = new ValidatedEntry ();
+            confirm_entry = new Granite.ValidatedEntry ();
             confirm_entry.sensitive = false;
             confirm_entry.visibility = false;
 
@@ -84,12 +84,13 @@ namespace SwitchboardPlugUserAccounts.Widgets {
             });
 
             confirm_entry.changed.connect (() => {
+                confirm_entry.is_valid = confirm_password ();
                 validate_form ();
             });
         }
 
         private void validate_form () {
-            is_valid = pw_entry.is_valid && confirm_password ();
+            is_valid = pw_entry.is_valid && confirm_entry.is_valid;
             validation_changed ();
         }
 
@@ -140,16 +141,13 @@ namespace SwitchboardPlugUserAccounts.Widgets {
         private bool confirm_password () {
             if (confirm_entry.text != "") {
                 if (pw_entry.text != confirm_entry.text) {
-                    confirm_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "process-error-symbolic");
                     confirm_entry_revealer.label = _("Passwords do not match");
                     confirm_entry_revealer.reveal_child = true;
                 } else {
-                    confirm_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "process-completed-symbolic");
                     confirm_entry_revealer.reveal_child = false;
                     return true;
                 }
             } else {
-                confirm_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, null);
                 confirm_entry_revealer.reveal_child = false;
             }
 


### PR DESCRIPTION
There's currently no way to set a validated entry to be of type "warn" instead of "error", so we can't replace the entry for choosing a password