### PR TITLE
ListFooter: Add label to Create button

### DIFF
--- a/src/Widgets/ListFooter.vala
+++ b/src/Widgets/ListFooter.vala
@@ -30,8 +30,12 @@ namespace SwitchboardPlugUserAccounts.Widgets {
         public signal void hide_undo_notification ();
 
         construct {
-            button_add = new Gtk.Button.from_icon_name ("list-add-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-            button_add.tooltip_text = _("Create user account");
+            button_add = new Gtk.Button () {
+                always_show_image = true,
+                image = new Gtk.Image.from_icon_name ("list-add-symbolic", Gtk.IconSize.SMALL_TOOLBAR),
+                label = _("Create Account…")
+            };
+            button_add.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
             button_remove = new Gtk.Button.from_icon_name ("list-remove-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
             button_remove.tooltip_text = _("Remove user account and its data");


### PR DESCRIPTION
This does the smallest thing to add a label to the Create button, making it more explicit and obvious. It keeps the Remove button for now, though we should probably move it to be inline on the rows eventually to match our newer list pattern.

![Screenshot from 2021-06-03 13-48-07](https://user-images.githubusercontent.com/611168/120703390-77ca6200-c472-11eb-9bae-5f44a8973133.png)
