### PR TITLE
Fix crash after deleting a newly added user; ensure UserItem destruct

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -120,7 +120,7 @@ namespace SwitchboardPlugUserAccounts {
             try {
                 foreach (Act.User user in get_removal_list ()) {
                     debug ("Removing user %s from system".printf (user.get_user_name ()));
-                    // Need to add a ref to stop possible after clearing the removal list.
+                    // Need to add a ref to stop possible crash after clearing the removal list.
                     user.ref ();
                     get_usermanager ().delete_user (user, true);
                 }

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -120,6 +120,8 @@ namespace SwitchboardPlugUserAccounts {
             try {
                 foreach (Act.User user in get_removal_list ()) {
                     debug ("Removing user %s from system".printf (user.get_user_name ()));
+                    // Need to add a ref to stop possible after clearing the removal list.
+                    user.ref ();
                     get_usermanager ().delete_user (user, true);
                 }
                 debug ("Clearing removal list");


### PR DESCRIPTION
Fixes #155 

An alternative to #156 that also allows UserItem destruction.
* Add an extra reference before asking accountservice to delete
* Make a weak signal connection between user and avatar

In passing the deprecated Hdy.Avatar function `set_image_load_func` is replaced with `set_loadable_icon`