### PR TITLE
Use systemd to detect display manager

### DIFF
--- a/src/Misc/Utils.vala
+++ b/src/Misc/Utils.vala
@@ -302,7 +302,7 @@ namespace SwitchboardPlugUserAccounts {
         }
     }
 
-    public static string get_display_manager () {
+    public static unowned string get_display_manager () {
         if (display_manager != null) {
             return display_manager;
         }
@@ -323,7 +323,7 @@ namespace SwitchboardPlugUserAccounts {
                 dm_path
             );
 
-            foreach (var name in dm.names) {
+            foreach (unowned string name in dm.names) {
                 // Ignore the generic "display-manager" name for this service
                 if (name != "display-manager.service") {
                     // Examples of the remaining names are "gdm.service" or "lightdm.service"

--- a/src/Misc/Utils.vala
+++ b/src/Misc/Utils.vala
@@ -20,7 +20,18 @@
 */
 
 namespace SwitchboardPlugUserAccounts {
+    [DBus (name = "org.freedesktop.systemd1.Unit")]
+    public interface SystemdUnit : GLib.Object {
+        public abstract string[] names { owned get; }
+    }
+
+    [DBus (name = "org.freedesktop.systemd1.Manager")]
+    public interface SystemdManager : GLib.Object {
+        public abstract ObjectPath get_unit (string name) throws GLib.Error;
+    }
+
     private static string[]? installed_languages = null;
+    private static string? display_manager = null;
 
     public static string[]? get_installed_languages () {
         if (installed_languages != null)
@@ -237,6 +248,11 @@ namespace SwitchboardPlugUserAccounts {
     }
 
     public static bool get_guest_session_state (string option) {
+        // We only support guest session stuff with lightdm
+        if (get_display_manager () != "lightdm") {
+            return false;
+        }
+
         string output;
         int status;
 
@@ -261,6 +277,11 @@ namespace SwitchboardPlugUserAccounts {
     }
 
     public static void set_guest_session_state (string option) {
+        // We only support guest session stuff with lightdm
+        if (get_display_manager () != "lightdm") {
+            return;
+        }
+
         if (get_permission ().allowed) {
             string output;
             int status;
@@ -279,5 +300,53 @@ namespace SwitchboardPlugUserAccounts {
                 warning (e.message);
             }
         }
+    }
+
+    public static string get_display_manager () {
+        if (display_manager != null) {
+            return display_manager;
+        }
+
+        try {
+            SystemdManager systemd = GLib.Bus.get_proxy_sync (
+                GLib.BusType.SYSTEM,
+                "org.freedesktop.systemd1",
+                "/org/freedesktop/systemd1"
+            );
+
+            // The systemd display-manager is a symlink to the real display manager unit
+            var dm_path = systemd.get_unit ("display-manager.service");
+
+            SystemdUnit dm = GLib.Bus.get_proxy_sync (
+                GLib.BusType.SYSTEM,
+                "org.freedesktop.systemd1",
+                dm_path
+            );
+
+            foreach (var name in dm.names) {
+                // Ignore the generic "display-manager" name for this service
+                if (name != "display-manager.service") {
+                    // Examples of the remaining names are "gdm.service" or "lightdm.service"
+                    // So strip .service off the end
+                    display_manager = name.replace (".service", "");
+                    return display_manager;
+                }
+            }
+        } catch (Error e) {
+            warning ("Unable to get display manager name from systemd, falling back to config files: %s", e.message);
+        }
+
+        string output = "";
+
+        try {
+            //TODO: add file location for different, non-debian-based distros
+            FileUtils.get_contents ("/etc/X11/default-display-manager", out output);
+        } catch (Error e) {
+            critical (e.message);
+            return "";
+        }
+
+        display_manager = output.slice (output.last_index_of ("/") + 1, output.length).chomp ();
+        return display_manager;
     }
 }

--- a/src/Widgets/UserListBox.vala
+++ b/src/Widgets/UserListBox.vala
@@ -126,19 +126,5 @@ namespace SwitchboardPlugUserAccounts.Widgets {
 
             guest_description_label.label = "<span font_size=\"small\">%s</span>".printf (state_string);
         }
-
-        private static string get_display_manager () {
-            string output = "";
-
-            try {
-                //TODO: add file location for different, non-debian-based distros
-                FileUtils.get_contents ("/etc/X11/default-display-manager", out output);
-            } catch (Error e) {
-                critical (e.message);
-                return "";
-            }
-
-            return output.slice (output.last_index_of ("/") + 1, output.length).chomp ();
-        }
     }
 }

--- a/src/Widgets/UserListBox.vala
+++ b/src/Widgets/UserListBox.vala
@@ -34,7 +34,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
 
             other_accounts_label = new Granite.HeaderLabel (_("Other Accounts"));
 
-            //only build the guest session list entry / row when lightDM is X11's display manager
+            //only build the guest session list entry / row when lightDM is the display manager
             if (get_display_manager () == "lightdm") {
                 var avatar = new Hdy.Avatar (32, null, false);
 


### PR DESCRIPTION
Instead of relying on a hardcoded Ubuntu path for detecting which display manager is in use, ask systemd what it's launching in the first instance, then fallback to the old way if that's not available.

Additionally guard execution of the `guest-session-toggle` binary with the display manager check as it's LightDM specific and produces a load of log spam if LightDM isn't available.