### PR TITLE
Update run-passwd from g-c-c

### DIFF
--- a/src/run-passwd.c
+++ b/src/run-passwd.c
@@ -168,7 +168,7 @@ spawn_passwd (PasswdHandler *passwd_handler, GError **error)
                                        &my_stderr,                      /* Stderr */
                                        error)) {                        /* GError */
 
-                /* An error occured */
+                /* An error occurred */
                 free_passwd_resources (passwd_handler);
 
                 g_strfreev (envp);
@@ -252,8 +252,6 @@ stop_passwd (PasswdHandler *passwd_handler)
 static void
 free_passwd_resources (PasswdHandler *passwd_handler)
 {
-        GError  *error = NULL;
-
         /* Remove the child watcher */
         if (passwd_handler->backend_child_watch_id != 0) {
 
@@ -265,28 +263,23 @@ free_passwd_resources (PasswdHandler *passwd_handler)
 
         /* Close IO channels (internal file descriptors are automatically closed) */
         if (passwd_handler->backend_stdin != NULL) {
+                g_autoptr(GError) error = NULL;
 
                 if (g_io_channel_shutdown (passwd_handler->backend_stdin, TRUE, &error) != G_IO_STATUS_NORMAL) {
                         g_warning ("Could not shutdown backend_stdin IO channel: %s", error->message);
-                        g_error_free (error);
-                        error = NULL;
                 }
 
-                g_io_channel_unref (passwd_handler->backend_stdin);
-                passwd_handler->backend_stdin = NULL;
+                g_clear_pointer (&passwd_handler->backend_stdin, g_io_channel_unref);
         }
 
         if (passwd_handler->backend_stdout != NULL) {
+                g_autoptr(GError) error = NULL;
 
                 if (g_io_channel_shutdown (passwd_handler->backend_stdout, TRUE, &error) != G_IO_STATUS_NORMAL) {
                         g_warning ("Could not shutdown backend_stdout IO channel: %s", error->message);
-                        g_error_free (error);
-                        error = NULL;
                 }
 
-                g_io_channel_unref (passwd_handler->backend_stdout);
-
-                passwd_handler->backend_stdout = NULL;
+                g_clear_pointer (&passwd_handler->backend_stdout, g_io_channel_unref);
         }
 
         /* Remove IO watcher */
@@ -321,9 +314,9 @@ free_passwd_resources (PasswdHandler *passwd_handler)
 static void
 io_queue_pop (GQueue *queue, GIOChannel *channel)
 {
-        gchar   *buf;
+        g_autofree gchar *buf = NULL;
         gsize   bytes_written;
-        GError  *error = NULL;
+        g_autoptr(GError) error = NULL;
 
         buf = g_queue_pop_head (queue);
 
@@ -331,12 +324,10 @@ io_queue_pop (GQueue *queue, GIOChannel *channel)
 
                 if (g_io_channel_write_chars (channel, buf, -1, &bytes_written, &error) != G_IO_STATUS_NORMAL) {
                         g_warning ("Could not write queue element \"%s\" to channel: %s", buf, error->message);
-                        g_error_free (error);
                 }
 
                 /* Ensure passwords are cleared from memory */
                 memset (buf, 0, strlen (buf));
-                g_free (buf);
         }
 }
 
@@ -377,8 +368,7 @@ io_watch_stdout (GIOChannel *source, GIOCondition condition, PasswdHandler *pass
 
         gchar           buf[BUFSIZE];           /* Temporary buffer */
         gsize           bytes_read;
-        GError          *gio_error = NULL;      /* Error returned by functions */
-        GError          *error = NULL;          /* Error sent to callbacks */
+        g_autoptr(GError) gio_error = NULL;
 
         gboolean        reinit = FALSE;
 
@@ -390,8 +380,6 @@ io_watch_stdout (GIOChannel *source, GIOCondition condition, PasswdHandler *pass
         if (g_io_channel_read_chars (source, buf, BUFSIZE, &bytes_read, &gio_error)
             != G_IO_STATUS_NORMAL) {
                 g_warning ("IO Channel read error: %s", gio_error->message);
-                g_error_free (gio_error);
-
                 return TRUE;
         }
 
@@ -404,7 +392,9 @@ io_watch_stdout (GIOChannel *source, GIOCondition condition, PasswdHandler *pass
 
                         if (is_string_complete (str->str, "assword: ", "failure", "wrong", "error", NULL)) {
 
-                                if (strstr (str->str, "assword: ") != NULL) {
+                                if (strstr (str->str, "assword: ") != NULL &&
+                                    strstr (str->str, "incorrect") == NULL &&
+                                    strstr (str->str, "urrent") == NULL) {
                                         /* Authentication successful */
 
                                         passwd_handler->backend_state = PASSWD_STATE_NEW;
@@ -417,6 +407,7 @@ io_watch_stdout (GIOChannel *source, GIOCondition condition, PasswdHandler *pass
 
                                 } else {
                                         /* Authentication failed */
+                                        g_autoptr(GError) error = NULL;
 
                                         error = g_error_new_literal (PASSWD_ERROR, PASSWD_ERROR_AUTH_FAILED,
                                                                      _("Authentication failed"));
@@ -433,8 +424,6 @@ io_watch_stdout (GIOChannel *source, GIOCondition condition, PasswdHandler *pass
                                                 passwd_handler->auth_cb (passwd_handler,
                                                                          error,
                                                                          passwd_handler->auth_cb_data);
-
-                                        g_error_free (error);
                                 }
 
                                 reinit = TRUE;
@@ -490,6 +479,7 @@ io_watch_stdout (GIOChannel *source, GIOCondition condition, PasswdHandler *pass
                                 }
                                 else {
                                         /* Ohnoes! */
+                                        g_autoptr(GError) error = NULL;
 
                                         if (strstr (str->str, "recovered") != NULL) {
                                                 /* What does this indicate?
@@ -549,9 +539,6 @@ io_watch_stdout (GIOChannel *source, GIOCondition condition, PasswdHandler *pass
                                                 passwd_handler->chpasswd_cb (passwd_handler,
                                                                              error,
                                                                              passwd_handler->chpasswd_cb_data);
-
-                                        g_error_free (error);
-
                                 }
 
                                 reinit = TRUE;
@@ -567,14 +554,13 @@ io_watch_stdout (GIOChannel *source, GIOCondition condition, PasswdHandler *pass
                                  * passwd will immediately ask for the new password,
                                  * so skip the AUTH phase */
                                 if (is_string_complete (str->str, "new", "New", NULL)) {
-                                        gchar *pw;
+                                        g_autofree gchar *pw = NULL;
 
                                         passwd_handler->backend_state = PASSWD_STATE_NEW;
 
                                         /* since passwd didn't ask for our old password
                                          * in this case, simply remove it from the queue */
                                         pw = g_queue_pop_head (passwd_handler->backend_stdin_queue);
-                                        g_free (pw);
 
                                         /* Pop the IO queue, i.e. send new password */
                                         io_queue_pop (passwd_handler->backend_stdin_queue, passwd_handler->backend_stdin);
@@ -677,9 +663,9 @@ passwd_authenticate (PasswdHandler *passwd_handler,
                      PasswdCallback cb,
                      const gpointer user_data)
 {
-        GError *error = NULL;
+        g_autoptr(GError) error = NULL;
 
-        /* Don't stop if we've already started chaging password */
+        /* Don't stop if we've already started changing password */
         if (passwd_handler->changing_password)
                 return;
 
@@ -699,8 +685,6 @@ passwd_authenticate (PasswdHandler *passwd_handler,
 
         if (!spawn_passwd (passwd_handler, &error)) {
                 g_warning ("%s", error->message);
-                g_error_free (error);
-
                 return;
         }
 
@@ -715,15 +699,13 @@ passwd_change_password (PasswdHandler *passwd_handler,
                         PasswdCallback cb,
                         const gpointer user_data)
 {
-        GError *error = NULL;
-
         passwd_handler->changing_password = TRUE;
 
         passwd_handler->new_password = new_password;
         passwd_handler->chpasswd_cb = cb;
         passwd_handler->chpasswd_cb_data = user_data;
 
-        /* Stop passwd if an error occured and it is still running */
+        /* Stop passwd if an error occurred and it is still running */
         if (passwd_handler->backend_state == PASSWD_STATE_ERR) {
 
                 /* Stop passwd, free resources */
@@ -731,17 +713,16 @@ passwd_change_password (PasswdHandler *passwd_handler,
         }
 
         /* Check that the backend is still running, or that an error
-         * has occured but it has not yet exited */
+         * has occurred but it has not yet exited */
         if (passwd_handler->backend_pid == -1) {
                 /* If it is not, re-run authentication */
+                g_autoptr(GError) error = NULL;
 
                 /* Spawn backend */
                 stop_passwd (passwd_handler);
 
                 if (!spawn_passwd (passwd_handler, &error)) {
                         g_warning ("%s", error->message);
-                        g_error_free (error);
-
                         return FALSE;
                 }
 
@@ -766,5 +747,3 @@ passwd_change_password (PasswdHandler *passwd_handler,
 
         return TRUE;
 }
-
-

--- a/src/run-passwd.h
+++ b/src/run-passwd.h
@@ -20,8 +20,7 @@
  * Authors: Milan Bouchet-Valat <nalimilan@club.fr>
  */
 
-#ifndef _RUN_PASSWD_H
-#define _RUN_PASSWD_H
+#pragma once
 
 struct PasswdHandler;
 
@@ -52,7 +51,4 @@ gboolean       passwd_change_password     (PasswdHandler *passwd_handler,
                                            const char    *new_password,
                                            PasswdCallback cb,
                                            const gpointer user_data);
-
-#endif /* _RUN_PASSWD_H */
-
 


### PR DESCRIPTION
This is a direct copy and paste from `gnome-control-center`, so lets update it from there.

Couple of useful bits of cleanup here and two bug fixes:

https://gitlab.gnome.org/GNOME/gnome-control-center/-/commit/7cbccd357814a6c0f2a8574d0f8b49da9e581b43
https://gitlab.gnome.org/GNOME/gnome-control-center/-/commit/65d3b71d98694055d4868dfa9e725203ab413619