### PR TITLE
Replace InfobarError with MessageDialog

### DIFF
--- a/src/Misc/InfobarNotifier.vala
+++ b/src/Misc/InfobarNotifier.vala
@@ -18,7 +18,6 @@
 */
 
 public class SwitchboardPlugUserAccounts.InfobarNotifier : Object {
-    public string error_message { get; set; default = ""; }
     public bool reboot_required { get; set; default = false; }
 
     private static GLib.Once<InfobarNotifier> instance;

--- a/src/Misc/UserUtils.vala
+++ b/src/Misc/UserUtils.vala
@@ -78,40 +78,5 @@ namespace SwitchboardPlugUserAccounts {
                 }
             }
         }
-
-        public void change_password (Act.UserPasswordMode mode, string? new_password) {
-            if (get_permission ().allowed) {
-                switch (mode) {
-                    case Act.UserPasswordMode.REGULAR:
-                        if (new_password != null) {
-                            debug ("Setting new password for %s".printf (user.get_user_name ()));
-                            user.set_password (new_password, "");
-                        }
-                        break;
-                    case Act.UserPasswordMode.NONE:
-                        debug ("Setting no password for %s".printf (user.get_user_name ()));
-                        user.set_password_mode (Act.UserPasswordMode.NONE);
-                        break;
-                    case Act.UserPasswordMode.SET_AT_LOGIN:
-                        debug ("Setting password mode to SET_AT_LOGIN for %s".printf (user.get_user_name ()));
-                        user.set_password_mode (Act.UserPasswordMode.SET_AT_LOGIN);
-                        break;
-                    default: break;
-                }
-            } else if (user == get_current_user ()) {
-                if (new_password != null) {
-                    // we are going to assume that if a normal user calls this method,
-                    // he is authenticated against the PasswdHandler
-                    Passwd.passwd_change_password (get_passwd_handler (), new_password, (h, e) => {
-                        if (e != null) {
-                            warning ("Password change for %s failed".printf (user.get_user_name ()));
-                            warning (e.message);
-                            InfobarNotifier.get_default ().error_message = e.message;
-                        } else
-                            debug ("Setting new password for %s (user context)".printf (user.get_user_name ()));
-                    });
-                }
-            }
-        }
     }
 }

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -26,7 +26,6 @@ namespace SwitchboardPlugUserAccounts {
     public class UserAccountsPlug : Switchboard.Plug {
         private Gtk.Grid? main_grid;
         private Gtk.InfoBar infobar;
-        private Gtk.InfoBar infobar_error;
         private Gtk.InfoBar infobar_reboot;
         private Gtk.LockButton lock_button;
         private Widgets.MainView main_view;
@@ -55,25 +54,6 @@ namespace SwitchboardPlugUserAccounts {
                 return main_grid;
             }
 
-            infobar_error = new Gtk.InfoBar ();
-            infobar_error.message_type = Gtk.MessageType.ERROR;
-            infobar_error.revealed = false;
-
-            var error_label = new Gtk.Label ("");
-
-            var error_content = infobar_error.get_content_area ();
-            error_content.add (error_label);
-
-            InfobarNotifier.get_default ().notify["error-message"].connect (() => {
-                var error_message = InfobarNotifier.get_default ().error_message;
-                if (error_message != "") {
-                    error_label.label = "%s: %s".printf (_("Password change failed"), error_message);
-                    infobar_error.revealed = true;
-                } else {
-                    infobar_error.revealed = false;
-                }
-            });
-
             infobar_reboot = new Gtk.InfoBar ();
             infobar_reboot.message_type = Gtk.MessageType.WARNING;
             infobar_reboot.revealed = false;
@@ -99,7 +79,6 @@ namespace SwitchboardPlugUserAccounts {
             main_view = new Widgets.MainView ();
 
             main_grid = new Gtk.Grid ();
-            main_grid.attach (infobar_error, 0, 0, 1, 1);
             main_grid.attach (infobar_reboot, 0, 1, 1, 1);
             main_grid.attach (infobar, 0, 2, 1, 1);
             main_grid.attach (main_view, 0, 3, 1, 1);


### PR DESCRIPTION
Instead of throwing an Infobar if we fail to set change the current user's password, throw a message dialog instead.

While we're here, move `change_password` to `UserSettingsView` since that's the only place it's used and we can call `get_toplevel` if the function is inside a Gtk.Widget