### PR TITLE
Fix avatar rotation

### DIFF
--- a/src/Dialogs/AvatarDialog.vala
+++ b/src/Dialogs/AvatarDialog.vala
@@ -45,7 +45,15 @@ public class SwitchboardPlugUserAccounts.Dialogs.AvatarDialog : Granite.MessageD
             cropview = new Widgets.CropView.from_pixbuf_with_size (pixbuf, 400, 400);
             cropview.quadratic_selection = true;
             cropview.handles_visible = false;
-            custom_bin.add (cropview);
+
+            var frame = new Gtk.Grid ();
+            frame.add (cropview);
+
+            var frame_context = frame.get_style_context ();
+            frame_context.add_class (Granite.STYLE_CLASS_CARD);
+            frame_context.add_class (Granite.STYLE_CLASS_CHECKERBOARD);
+
+            custom_bin.add (frame);
         } catch (Error e) {
             critical (e.message);
             button_change.set_sensitive (false);

--- a/src/Dialogs/AvatarDialog.vala
+++ b/src/Dialogs/AvatarDialog.vala
@@ -45,15 +45,7 @@ public class SwitchboardPlugUserAccounts.Dialogs.AvatarDialog : Granite.MessageD
             cropview = new Widgets.CropView.from_pixbuf_with_size (pixbuf, 400, 400);
             cropview.quadratic_selection = true;
             cropview.handles_visible = false;
-
-            var frame = new Gtk.Grid ();
-            frame.add (cropview);
-
-            var frame_context = frame.get_style_context ();
-            frame_context.add_class (Granite.STYLE_CLASS_CARD);
-            frame_context.add_class (Granite.STYLE_CLASS_CHECKERBOARD);
-
-            custom_bin.add (frame);
+            custom_bin.add (cropview);
         } catch (Error e) {
             critical (e.message);
             button_change.set_sensitive (false);

--- a/src/Dialogs/AvatarDialog.vala
+++ b/src/Dialogs/AvatarDialog.vala
@@ -41,7 +41,7 @@ public class SwitchboardPlugUserAccounts.Dialogs.AvatarDialog : Granite.MessageD
         response.connect (on_response);
 
         try {
-            Gdk.Pixbuf pixbuf = new Gdk.Pixbuf.from_file (pixbuf_path).apply_embedded_orientation ();
+            var pixbuf = new Gdk.Pixbuf.from_file (pixbuf_path).apply_embedded_orientation ();
             cropview = new Widgets.CropView.from_pixbuf_with_size (pixbuf, 400, 400);
             cropview.quadratic_selection = true;
             cropview.handles_visible = false;

--- a/src/Dialogs/AvatarDialog.vala
+++ b/src/Dialogs/AvatarDialog.vala
@@ -41,7 +41,8 @@ public class SwitchboardPlugUserAccounts.Dialogs.AvatarDialog : Granite.MessageD
         response.connect (on_response);
 
         try {
-            cropview = new Widgets.CropView.from_pixbuf_with_size (new Gdk.Pixbuf.from_file (pixbuf_path), 400, 300);
+            Gdk.Pixbuf pixbuf = new Gdk.Pixbuf.from_file (pixbuf_path).apply_embedded_orientation ();
+            cropview = new Widgets.CropView.from_pixbuf_with_size (pixbuf, 400, 400);
             cropview.quadratic_selection = true;
             cropview.handles_visible = false;
 

--- a/src/Widgets/CropView.vala
+++ b/src/Widgets/CropView.vala
@@ -116,19 +116,6 @@ namespace SwitchboardPlugUserAccounts.Widgets {
          */
         const int RADIUS = 12;
 
-        public CropView.from_pixbuf (Gdk.Pixbuf pixbuf) {
-            this.add_events (Gdk.EventMask.POINTER_MOTION_MASK | Gdk.EventMask.BUTTON_MOTION_MASK);
-            this.pixbuf = pixbuf;
-
-            if (pixbuf.get_width () > pixbuf.get_height ()) {
-                area = { 5, 5, _pixbuf.get_height () / 2, _pixbuf.get_height () / 2};
-            } else if (pixbuf.get_width () < pixbuf.get_height ()) {
-                area = { 5, 5, pixbuf.get_width () / 2, pixbuf.get_width () / 2};
-            } else {
-                area = { 5, 5, pixbuf.get_width () / 2, pixbuf.get_height () / 2};
-            }
-        }
-
         public CropView.from_pixbuf_with_size (Gdk.Pixbuf pixbuf, int x, int y) {
             this.add_events (Gdk.EventMask.POINTER_MOTION_MASK | Gdk.EventMask.BUTTON_MOTION_MASK);
             this.pixbuf = pixbuf;

--- a/src/Widgets/CropView.vala
+++ b/src/Widgets/CropView.vala
@@ -129,26 +129,25 @@ namespace SwitchboardPlugUserAccounts.Widgets {
             }
         }
 
-        public CropView.from_pixbuf_with_size (Gdk.Pixbuf pixbuf, int x, int y, bool quadratic_selection = false) {
+        public CropView.from_pixbuf_with_size (Gdk.Pixbuf pixbuf, int x, int y) {
             this.add_events (Gdk.EventMask.POINTER_MOTION_MASK | Gdk.EventMask.BUTTON_MOTION_MASK);
             this.pixbuf = pixbuf;
-            this.quadratic_selection = quadratic_selection;
 
-            if (pixbuf.get_width () > pixbuf.get_height ()) {
-                    area = { 5, 5, _pixbuf.get_height () / 2, _pixbuf.get_height () / 2 };
+            // Use a default selection of 75% in the center of the image
+            int area_dimension = int.min (pixbuf.get_width (), pixbuf.get_height ()) * 3 / 4;
+            int area_position_x = (pixbuf.get_width () - area_dimension) / 2;
+            int area_position_y = (pixbuf.get_height () - area_dimension) / 2;
 
-                double temp_scale = (double) x / (double) pixbuf.get_width ();
-                if (pixbuf.get_height () * temp_scale < y)
-                    y = (int) (pixbuf.get_height () * temp_scale);
-            } else if (pixbuf.get_width () < pixbuf.get_height ()) {
-                    area = { 5, 5, _pixbuf.get_width () / 2, pixbuf.get_width () / 2 };
+            area = {
+                area_position_x,
+                area_position_y,
+                area_dimension,
+                area_dimension
+            };
 
-                double temp_scale = (double) y / (double) pixbuf.get_height ();
-                if (pixbuf.get_width () * temp_scale < x)
-                    x = (int) (pixbuf.get_width () * temp_scale);
-            } else
-                area = { 5, 5, _pixbuf.get_width () / 2, pixbuf.get_height () / 2 };
-
+            // Set the size to fit inside the requested size
+            x = int.min (x, x * pixbuf.get_width () / pixbuf.get_height ());
+            y = int.min (y, y * pixbuf.get_height () / pixbuf.get_width ());
             set_size_request (x, y);
         }
 

--- a/src/Widgets/Popovers/AvatarPopover.vala
+++ b/src/Widgets/Popovers/AvatarPopover.vala
@@ -85,7 +85,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
                 string uri = file_dialog.get_preview_uri ();
                 if (uri != null && uri.has_prefix ("file://")) {
                     try {
-                        Gdk.Pixbuf pixbuf = new Gdk.Pixbuf.from_file_at_scale (
+                        var pixbuf = new Gdk.Pixbuf.from_file_at_scale (
                             file_dialog.get_file ().get_path (),
                             preview_area.pixel_size,
                             preview_area.pixel_size,

--- a/src/Widgets/Popovers/AvatarPopover.vala
+++ b/src/Widgets/Popovers/AvatarPopover.vala
@@ -68,7 +68,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
             filter.add_mime_type ("image/jpg");
             filter.add_mime_type ("image/png");
 
-            var preview_area = new Granite.AsyncImage (false);
+            var preview_area = new Gtk.Image ();
             preview_area.pixel_size = 256;
             preview_area.margin_end = 12;
 
@@ -84,18 +84,17 @@ namespace SwitchboardPlugUserAccounts.Widgets {
             file_dialog.update_preview.connect (() => {
                 string uri = file_dialog.get_preview_uri ();
                 if (uri != null && uri.has_prefix ("file://")) {
-                    preview_area.set_from_gicon_async.begin (
-                        new FileIcon (file_dialog.get_file ()),
-                        256,
-                        null,
-                        (obj, res) => {
-                            try {
-                                preview_area.set_from_gicon_async.end (res);
-                                preview_area.show ();
-                            } catch (Error e) {
-                                preview_area.hide ();
-                            }
-                        });
+                    try {
+                        Gdk.Pixbuf pixbuf = new Gdk.Pixbuf.from_file_at_scale (
+                            file_dialog.get_file ().get_path (),
+                            250,
+                            250,
+                            true
+                        ).apply_embedded_orientation ();
+                        preview_area.set_from_pixbuf (pixbuf);
+                    } catch (Error e) {
+                        preview_area.hide ();
+                    }
                 } else {
                     preview_area.hide ();
                 }

--- a/src/Widgets/Popovers/AvatarPopover.vala
+++ b/src/Widgets/Popovers/AvatarPopover.vala
@@ -87,8 +87,8 @@ namespace SwitchboardPlugUserAccounts.Widgets {
                     try {
                         Gdk.Pixbuf pixbuf = new Gdk.Pixbuf.from_file_at_scale (
                             file_dialog.get_file ().get_path (),
-                            250,
-                            250,
+                            preview_area.pixel_size,
+                            preview_area.pixel_size,
                             true
                         ).apply_embedded_orientation ();
                         preview_area.set_from_pixbuf (pixbuf);


### PR DESCRIPTION
This fixes #114, where the selected image is not rotated correctly.

### Before:

![before-filepicker](https://user-images.githubusercontent.com/12174852/227798770-b7555b13-5df1-4f05-b07e-7660506edf32.png)

![before-cropview](https://user-images.githubusercontent.com/12174852/227798786-2679c195-278b-4e6b-b63d-8de8c7d3e771.png)

### After:

![after-filepicker](https://user-images.githubusercontent.com/12174852/227798889-cc2ac891-cdc1-4e52-9103-f860f9b56588.png)

![after-cropview](https://user-images.githubusercontent.com/12174852/227798894-f273e9a4-d8ec-407f-82a0-a0eaed55eee2.png)



### More info

I had to use the synchronous API to read the file to a Pixbuf and to apply the orientation to the image. Since the AsyncImage was removed from Granite sometime last year, and since we are only reading one image file at a time, I don’t think this will cause a great performance problem.

I used this opportunity to make the default selection (which was 50% linear dimension and at the top-left corner) a bit more universally useful at 75% linear dimension and in the center of the image. See the example images above.

I have also used this opportunity to clean up some of the code that creates the CropView, I hope that is all right.

The changes are best reviewed per-commit.

If you need me to make any changes, please let me know.