### PR TITLE
policy: Do not specify the gettext-domain

### DIFF
--- a/data/useraccounts.policy.in.in
+++ b/data/useraccounts.policy.in.in
@@ -7,8 +7,8 @@
   <vendor_url>https://elementary.io/</vendor_url>
 
   <action id="io.elementary.settings.useraccounts.administration">
-    <description gettext-domain="@GETTEXT_PACKAGE@">Manage user accounts</description>
-    <message gettext-domain="@GETTEXT_PACKAGE@">Authentication is required to change user data</message>
+    <description>Manage user accounts</description>
+    <message>Authentication is required to change user data</message>
     <icon_name>system-users</icon_name>
     <defaults>
       <allow_any>no</allow_any>

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -29,9 +29,6 @@ namespace SwitchboardPlugUserAccounts {
         private Gtk.LockButton lock_button;
         private Widgets.MainView main_view;
 
-        //translatable string for io.elementary.switchboard.useraccounts.administration policy
-        public const string policy_message = _("Authentication is required to change user data"); // vala-lint=naming-convention
-
         public UserAccountsPlug () {
             GLib.Intl.bindtextdomain (Build.GETTEXT_PACKAGE, Build.LOCALEDIR);
             GLib.Intl.bind_textdomain_codeset (Build.GETTEXT_PACKAGE, "UTF-8");


### PR DESCRIPTION
Same fix with https://github.com/elementary/switchboard-plug-locale/pull/162 but we embeded the same message in the plug domain thus the message in the polkit dialog is shown as translated as expected.

However, it is better to keep the message only in the policy file for maintainability.