### PR TITLE
UserSettingsView: Correct display name of Locale plug

### DIFF
--- a/src/Views/UserSettingsView.vala
+++ b/src/Views/UserSettingsView.vala
@@ -200,7 +200,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
             } else {
                 language_button = new Gtk.LinkButton.with_label ("settings://language", "Language") {
                     halign = Gtk.Align.START,
-                    tooltip_text = _("Click to switch to Language & Locale Settings")
+                    tooltip_text = _("Click to switch to Language & Region Settings")
                 };
 
                 content_grid.attach (language_button, 1, 2);


### PR DESCRIPTION
Really tiny thing but make sure to use the correct user-facing name.

https://github.com/elementary/switchboard-plug-locale/blob/23d3695b030dc846351eebbbe86197b9dbcd2969/data/locale.metainfo.xml.in#L10