### PR TITLE
meson: Correct GETTEXT_PACKAGE

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,7 @@ polkit_actiondir = polkit_dep.get_pkgconfig_variable('actiondir', define_variabl
 posix_dep = meson.get_compiler('vala').find_library('posix')
 
 add_project_arguments(
-    '-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()),
+    '-DGETTEXT_PACKAGE="@0@"'.format(gettext_name),
     '-DG_LOG_DOMAIN="@0@"'.format(meson.project_name()),
     '-DGNOME_DESKTOP_USE_UNSTABLE_API',
     language:'c'


### PR DESCRIPTION
This fixes the plug is always shown in English regardless of user language in OS 8.0 Daily