### PR TITLE
meson: Fix deprecations

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -7,7 +7,7 @@ gettext_declaration = configure_file(
 i18n.merge_file(
     input: gettext_declaration,
     output: gettext_name + '.policy',
-    po_dir: meson.source_root() / 'po' / 'extra',
+    po_dir: meson.project_source_root() / 'po' / 'extra',
     install: true,
     install_dir: polkit_actiondir
 )
@@ -15,7 +15,7 @@ i18n.merge_file(
 i18n.merge_file(
     input: 'useraccounts.metainfo.xml.in',
     output: gettext_name + '.metainfo.xml',
-    po_dir: meson.source_root() / 'po' / 'extra',
+    po_dir: meson.project_source_root() / 'po' / 'extra',
     type: 'xml',
     install: true,
     install_dir: datadir / 'metainfo',

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'useraccounts',
     'vala', 'c',
-    meson_version: '>= 0.46.1',
+    meson_version: '>= 0.58.0',
     version: '8.0.0'
 )
 
@@ -16,11 +16,11 @@ libdir = join_paths(prefix, get_option('libdir'))
 localedir = join_paths(prefix, get_option('localedir'))
 
 switchboard_dep = dependency('switchboard-3')
-switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir])
+switchboard_plugsdir = switchboard_dep.get_variable('plugsdir', pkgconfig_define: ['libdir', libdir])
 pkgdatadir = switchboard_plugsdir / 'system' / 'useraccounts'
 
 polkit_dep = dependency('polkit-gobject-1')
-polkit_actiondir = polkit_dep.get_pkgconfig_variable('actiondir', define_variable: ['prefix', prefix])
+polkit_actiondir = polkit_dep.get_variable('actiondir', pkgconfig_define: ['prefix', prefix])
 
 posix_dep = meson.get_compiler('vala').find_library('posix')
 

--- a/po/extra/meson.build
+++ b/po/extra/meson.build
@@ -1,5 +1,5 @@
 i18n.gettext('extra',
-    args: '--directory=' + meson.source_root(),
+    args: '--directory=' + meson.project_source_root(),
     preset: 'glib',
     install: false,
 )

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,5 +1,5 @@
 i18n.gettext(gettext_name,
-    args: '--directory=' + meson.source_root(),
+    args: '--directory=' + meson.project_source_root(),
     preset: 'glib'
 )
 


### PR DESCRIPTION
Now it requires meson >= 0.58.0 because of `varname` positional argument of `get_variable()`:

https://mesonbuild.com/Reference-manual_returned_dep.html#arguments5