### PR TITLE
UserSettingsView: set region revealer overflow visible

### DIFF
--- a/src/Views/UserSettingsView.vala
+++ b/src/Views/UserSettingsView.vala
@@ -155,6 +155,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
 
                 var region_revealer = new Gtk.Revealer () {
                     child = region_box,
+                    overflow = VISIBLE,
                     transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN,
                     reveal_child = true
                 };


### PR DESCRIPTION
Fixes a small visual bug where box shadow is cut off for the region dropdown