### PR TITLE
Control: fix maintainer field

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: io.elementary.settings.useraccounts
 Section: x11
 Priority: optional
-Maintainer: elementary, Inc. <builds@elementary.io>
+Maintainer: elementary <builds@elementary.io>
 Build-Depends: debhelper (>= 10.5.1),
                libaccountsservice-dev,
                libadwaita-1-dev,


### PR DESCRIPTION
Builds on Resolute is failing due to this: https://code.launchpad.net/~elementary-os/+recipe/settings-useraccounts-daily

```
dpkg-buildpackage: info: source package io.elementary.settings.useraccounts
dpkg-buildpackage: info: source version 8.0.1+r1394+pkg683~daily~ubuntu26.04.1
dpkg-buildpackage: info: source distribution resolute
dpkg-buildpackage: info: source changed by Launchpad Package Builder <noreply@launchpad.net>
 dpkg-source -i -I.bzr -I.git --before-build .
dpkg-source: error: cannot parse Maintainer field value "elementary, Inc. <builds@elementary.io>"
dpkg-buildpackage: error: dpkg-source -i -I.bzr -I.git --before-build . subprocess failed with exit status 25
[Sun Mar 22 21:07:24 2026]
RUN: /usr/share/launchpad-buildd/bin/in-target scan-for-processes --backend=chroot --series=resolute --abi-tag=amd64 --isa-tag=amd64 RECIPEBRANCHBUILD-4021595
Scanning for processes to kill in build RECIPEBRANCHBUILD-4021595
```